### PR TITLE
Changed -l to --long to address rclone not printing remote types.

### DIFF
--- a/rclone_script-install.sh
+++ b/rclone_script-install.sh
@@ -107,7 +107,7 @@ function dialogShowProgress ()
 function dialogShowSummary ()
 {
 	# list all remotes and their type
-	remotes=$(rclone listremotes -l)
+	remotes=$(rclone listremotes --long)
 	
 	# get line with RETROPIE remote
 	retval=$(grep -i "^retropie:" <<< ${remotes})

--- a/rclone_script-menu.sh
+++ b/rclone_script-menu.sh
@@ -36,7 +36,7 @@ function log ()
 function getTypeOfRemote ()
 {
 	# list all remotes and their type
-	remotes=$(rclone listremotes -l)
+	remotes=$(rclone listremotes --long)
 	
 	# get line wiht RETROPIE remote
 	retval=$(grep -i "^retropie:" <<< ${remotes})

--- a/rclone_script-uninstall.sh
+++ b/rclone_script-uninstall.sh
@@ -210,7 +210,7 @@ function uninstaller ()
 function saveRemote ()
 {
 	# list all remotes and their type
-	remotes=$(rclone listremotes -l)
+	remotes=$(rclone listremotes --long)
 	
 	# get line with RETROPIE remote
 	retval=$(grep -i "^retropie:" <<< ${remotes})

--- a/rclone_script.sh
+++ b/rclone_script.sh
@@ -142,7 +142,7 @@ function prepareFilter ()
 function getTypeOfRemote ()
 {
 	# list all remotes and their type
-	remotes=$(rclone listremotes -l)
+	remotes=$(rclone listremotes --long)
 	
 	# get line with RETROPIE remote
 	retval=$(grep -i "^retropie:" <<< ${remotes})


### PR DESCRIPTION
Not sure why -l isn't working, but using the full --long seems to work fine.

Thanks for this awesome script!