### PR TITLE
Psp save support

### DIFF
--- a/emulator_settings.xml
+++ b/emulator_settings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<emulators>
+    <emulator>
+        <name>ppsspp</name>
+        <saveFilePath>/opt/retropie/configs/psp/PSP/SAVEDATA</saveFilePath>
+        <saveStatePath>/opt/retropie/configs/psp/PSP/PPSSPP_STATE</saveStatePath>
+        <saveFileExtensions>
+            <ext>SYS</ext>
+            <ext>PNG</ext>
+            <ext>SFO</ext>
+        </saveFileExtensions>
+    </emulator>
+</emulators>

--- a/emulator_settings.xml
+++ b/emulator_settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <emulators>
     <emulator>
-        <name>ppsspp</name>
+        <name>lr-ppsspp</name>
         <saveFilePath>/opt/retropie/configs/psp/PSP/SAVEDATA</saveFilePath>
         <saveStatePath>/opt/retropie/configs/psp/PSP/PPSSPP_STATE</saveStatePath>
         <saveFileExtensions>

--- a/emulator_settings.xml
+++ b/emulator_settings.xml
@@ -13,9 +13,6 @@
         <name>ppsspp</name>
         <saveFilePath>/opt/retropie/configs/psp/</saveFilePath>
         <saveStatePath>/opt/retropie/configs/psp/PSP/PPSSPP_STATE</saveFilePath>
-        <saveStateFileExtensions enable="true">
-            <ext>state</ext>
-        </saveStateFileExtensions>
         <saveFileExtensions>
             <ext>SYS</ext>
             <ext>PNG</ext>

--- a/emulator_settings.xml
+++ b/emulator_settings.xml
@@ -8,6 +8,7 @@
             <ext>SYS</ext>
             <ext>PNG</ext>
             <ext>SFO</ext>
+            <ext>state</ext>
         </saveFileExtensions>
     </emulator>
 </emulators>

--- a/emulator_settings.xml
+++ b/emulator_settings.xml
@@ -11,7 +11,7 @@
     </emulator>
     <emulator>
         <name>ppsspp</name>
-        <saveFilePath>/opt/retropie/configs/psp/PSP/SAVEDATA</saveFilePath>
+        <saveFilePath>/opt/retropie/configs/psp/</saveFilePath>
         <saveStatePath>/opt/retropie/configs/psp/PSP/PPSSPP_STATE</saveStatePath>
         <saveFileExtensions>
             <ext>SYS</ext>

--- a/emulator_settings.xml
+++ b/emulator_settings.xml
@@ -12,7 +12,10 @@
     <emulator>
         <name>ppsspp</name>
         <saveFilePath>/opt/retropie/configs/psp/</saveFilePath>
-        <saveStatePath>/opt/retropie/configs/psp/PSP/PPSSPP_STATE</saveStatePath>
+        <saveStatePath>/opt/retropie/configs/psp/PSP/PPSSPP_STATE</saveFilePath>
+        <saveStateFileExtensions enable="true">
+            <ext>state</ext>
+        </saveStateFileExtensions>
         <saveFileExtensions>
             <ext>SYS</ext>
             <ext>PNG</ext>

--- a/emulator_settings.xml
+++ b/emulator_settings.xml
@@ -2,6 +2,15 @@
 <emulators>
     <emulator>
         <name>lr-ppsspp</name>
+        <saveFileExtensions>
+            <ext>SYS</ext>
+            <ext>PNG</ext>
+            <ext>SFO</ext>
+            <ext>state</ext>
+        </saveFileExtensions>
+    </emulator>
+    <emulator>
+        <name>ppsspp</name>
         <saveFilePath>/opt/retropie/configs/psp/PSP/SAVEDATA</saveFilePath>
         <saveStatePath>/opt/retropie/configs/psp/PSP/PPSSPP_STATE</saveStatePath>
         <saveFileExtensions>

--- a/rclone_script-install.sh
+++ b/rclone_script-install.sh
@@ -17,7 +17,7 @@ UNDERLINE="\Zu"
 
 
 # global variables
-url="https://raw.githubusercontent.com/Jandalf81/rclone_script"
+url="https://raw.githubusercontent.com/Dannflower/rclone_script"
 branch="master"
 
 # configuration variables

--- a/rclone_script-install.sh
+++ b/rclone_script-install.sh
@@ -17,7 +17,7 @@ UNDERLINE="\Zu"
 
 
 # global variables
-url="https://raw.githubusercontent.com/Dannflower/rclone_script"
+url="https://raw.githubusercontent.com/Jandalf81/rclone_script"
 branch="master"
 
 # configuration variables

--- a/rclone_script-install.sh
+++ b/rclone_script-install.sh
@@ -107,7 +107,7 @@ function dialogShowProgress ()
 function dialogShowSummary ()
 {
 	# list all remotes and their type
-	remotes=$(rclone listremotes -l)
+	remotes=$(rclone listremotes --long)
 	
 	# get line with RETROPIE remote
 	retval=$(grep -i "^retropie:" <<< ${remotes})

--- a/rclone_script-install.sh
+++ b/rclone_script-install.sh
@@ -18,7 +18,7 @@ UNDERLINE="\Zu"
 
 # global variables
 url="https://raw.githubusercontent.com/Dannflower/rclone_script"
-branch="psp-save-support"
+branch="master"
 
 # configuration variables
 remotebasedir=""

--- a/rclone_script-install.sh
+++ b/rclone_script-install.sh
@@ -18,7 +18,7 @@ UNDERLINE="\Zu"
 
 # global variables
 url="https://raw.githubusercontent.com/Dannflower/rclone_script"
-branch="master"
+branch="psp-save-support"
 
 # configuration variables
 remotebasedir=""
@@ -647,7 +647,8 @@ function 4aGetRCLONE_SCRIPT ()
 		wget -N -P ~/scripts/rclone_script ${url}/${branch}/rclone_script.sh --append-output="${logfile}" &&
 		wget -N -P ~/scripts/rclone_script ${url}/${branch}/rclone_script-menu.sh --append-output="${logfile}" &&
 		wget -N -P ~/scripts/rclone_script ${url}/${branch}/rclone_script-uninstall.sh --append-output="${logfile}" &&
-		
+		wget -N -P ~/scripts/rclone_script ${url}/${branch}/emulator_settings.xml --append-output="${logfile}" &&
+
 		# change mod
 		chmod +x ~/scripts/rclone_script/rclone_script.sh >> "${logfile}" &&
 		chmod +x ~/scripts/rclone_script/rclone_script-menu.sh >> "${logfile}" &&

--- a/rclone_script-menu.sh
+++ b/rclone_script-menu.sh
@@ -36,7 +36,7 @@ function log ()
 function getTypeOfRemote ()
 {
 	# list all remotes and their type
-	remotes=$(rclone listremotes -l)
+	remotes=$(rclone listremotes --long)
 	
 	# get line wiht RETROPIE remote
 	retval=$(grep -i "^retropie:" <<< ${remotes})

--- a/rclone_script-uninstall.sh
+++ b/rclone_script-uninstall.sh
@@ -210,7 +210,7 @@ function uninstaller ()
 function saveRemote ()
 {
 	# list all remotes and their type
-	remotes=$(rclone listremotes -l)
+	remotes=$(rclone listremotes --long)
 	
 	# get line with RETROPIE remote
 	retval=$(grep -i "^retropie:" <<< ${remotes})

--- a/rclone_script.sh
+++ b/rclone_script.sh
@@ -169,6 +169,7 @@ function prepareSaveFilters ()
 		localFilter="${romfilebase//\[/\\[}"
 		localFilter="${localFilter//\]/\\]}.*"
 		remoteFilter="${localFilter}"
+		localFilter=("-iname" "${localFilter}")
 
 	else
 
@@ -336,7 +337,7 @@ function uploadSaves ()
 		
 		return
 	fi
-
+	
 	localfiles=$(find ${saveFilePath} -type f "${localFilter[@]}")
 	
 	if [ "${localfiles}" = "" ]

--- a/rclone_script.sh
+++ b/rclone_script.sh
@@ -12,7 +12,7 @@ UNDERLINE=$(tput smul)
 # include settings file
 config=~/scripts/rclone_script/rclone_script.ini
 source ${config}
-logLevel=3
+logLevel=2
 
 # include emulator specific settings
 emu_settings=~/scripts/rclone_script/emulator_settings.xml

--- a/rclone_script.sh
+++ b/rclone_script.sh
@@ -147,7 +147,7 @@ function getSaveFilePath ()
 		log 3 "Using default save file path for emulator: ${emulator}"
 
 		# Default to the normal saves directory
-		saveFilePath="~/RetroPie/saves/${system}"
+		saveFilePath=~/RetroPie/saves/${system}
 	fi
 
 	log 3 "Save file path: ${saveFilePath}"

--- a/rclone_script.sh
+++ b/rclone_script.sh
@@ -142,7 +142,7 @@ function prepareFilter ()
 function getTypeOfRemote ()
 {
 	# list all remotes and their type
-	remotes=$(rclone listremotes -l)
+	remotes=$(rclone listremotes --long)
 	
 	# get line with RETROPIE remote
 	retval=$(grep -i "^retropie:" <<< ${remotes})


### PR DESCRIPTION
Adding support for PSP game saves and any other emulator that uses save formats more complex than <game_name>.* via the emulator_settings.xml file.

Added the ability to define custom save file paths in the even an emulator does not adhere to retroarch.cfg files, such as the non-lr version of ppsspp.